### PR TITLE
feat: Add app own design system with colorScheme, typography

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -1,17 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="deploymentTargetDropDown">
-    <runningDeviceTargetSelectedWithDropDown>
-      <Target>
-        <type value="RUNNING_DEVICE_TARGET" />
-        <deviceKey>
-          <Key>
-            <type value="VIRTUAL_DEVICE_PATH" />
-            <value value="C:\Users\MinSeo\.android\avd\Resizable_Experimental_API_34.avd" />
-          </Key>
-        </deviceKey>
-      </Target>
-    </runningDeviceTargetSelectedWithDropDown>
     <targetSelectedWithDropDown>
       <Target>
         <type value="QUICK_BOOT_TARGET" />

--- a/presentation/src/main/java/com/meokq/presentation/model/QuestStatus.kt
+++ b/presentation/src/main/java/com/meokq/presentation/model/QuestStatus.kt
@@ -1,30 +1,56 @@
 package com.meokq.presentation.model
 
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
-import com.meokq.presentation.theme.BackGround
-import com.meokq.presentation.theme.BadgeBlue
-import com.meokq.presentation.theme.BadgeGreen
-import com.meokq.presentation.theme.BadgeRed
-import com.meokq.presentation.theme.Blue
-import com.meokq.presentation.theme.Gray300
-import com.meokq.presentation.theme.Green
-import com.meokq.presentation.theme.Red
-import com.meokq.presentation.theme.TextBlack
+import com.meokq.presentation.theme.MeokQTheme
 
 enum class QuestStatus(
     val status: String,
-    val text: String,
-    val textColor: Color,
-    val backgroundColor: Color,
 ) {
-    PUBLISHED("published", "수락전", Gray300, BackGround),
-    PENDING("pending", "진행중", Blue, BadgeBlue),
-    REJECTED("rejected", "재도전", Red, BadgeRed),
-    APPROVED("approved", "완료", Green, BadgeGreen)
+    PUBLISHED("published"),
+    PENDING("pending"),
+    REJECTED("rejected"),
+    APPROVED("approved")
 }
+
 val questStatusMap = mapOf(
     "퀘스트" to QuestStatus.PUBLISHED,
     "진행중" to QuestStatus.PENDING,
     "재도전" to QuestStatus.REJECTED,
     "완료" to QuestStatus.APPROVED,
 )
+
+data class QuestStatusUI(val text: String, val textColor: Color, val backgroundColor: Color)
+
+@Composable
+fun QuestStatus.ui(): QuestStatusUI {
+    return when (this) {
+        QuestStatus.PUBLISHED -> {
+            QuestStatusUI(
+                "수락전",
+                MeokQTheme.colorScheme.gray300,
+                MeokQTheme.colorScheme.background
+            )
+        }
+
+        QuestStatus.PENDING -> {
+            QuestStatusUI(
+                "진행중",
+                MeokQTheme.colorScheme.blue,
+                MeokQTheme.colorScheme.badgeBlue
+            )
+        }
+
+        QuestStatus.REJECTED -> {
+            QuestStatusUI("재도전", MeokQTheme.colorScheme.red, MeokQTheme.colorScheme.badgeRed)
+        }
+
+        QuestStatus.APPROVED -> {
+            QuestStatusUI(
+                "완료",
+                MeokQTheme.colorScheme.green,
+                MeokQTheme.colorScheme.badgeGreen
+            )
+        }
+    }
+}

--- a/presentation/src/main/java/com/meokq/presentation/theme/Color.kt
+++ b/presentation/src/main/java/com/meokq/presentation/theme/Color.kt
@@ -3,30 +3,26 @@ package com.meokq.presentation.theme
 import androidx.compose.ui.graphics.Color
 
 
-val Primary = Color(0xFFFFEA00)
-val NotificationYellow  = Color(0xFFFFCD00)
-val TabYellow  = Color(0xFFFBE176)
-val BadgeYellow  = Color(0xFFFDF6E6)
-val TextYellow  = Color(0xFFE2BC32)
-val BackGround = Color(0xFFF6F6F6)
-val KakaoLoginButton = Color(0xFFFEE500)
-
-val White = Color(0xFFFFFFFF)
-val TextBlack = Color(0xFF000000)
-val Gray400 = Color(0xFF575B6C)
-val Gray300 = Color(0xFF848794)
-val Gray200 = Color(0xFFB3B4B6)
-val Gray100 = Color(0xFFE8E8E8)
-val ShadowColor = Color(0x29000000)
-
-val Red  = Color(0xFFF16969)
-val BadgeRed  = Color(0xFFFFEAEA)
-
-val Blue  = Color(0xFF339DEA)
-val BadgeBlue  = Color(0xFFE2F1FF)
-
-val Green  = Color(0xFF48B236)
-val BadgeGreen  = Color(0xFFD9EED3)
-
+val defaultColors = MeokQColorScheme(
+    primary = Color(0xFFFFEA00),
+    notificationYellow = Color(0xFFFFCD00),
+    tabYellow = Color(0xFFFBE176),
+    badgeYellow = Color(0xFFFDF6E6),
+    textYellow = Color(0xFFE2BC32),
+    background = Color(0xFFF6F6F6),
+    kakaoLoginButton = Color(0xFFFEE500),
+    textBlack = Color(0xFF000000),
+    shadowColor = Color(0x29000000),
+    red = Color(0xFFF16969),
+    badgeRed = Color(0xFFFFEAEA),
+    blue = Color(0xFF339DEA),
+    badgeBlue = Color(0xFFE2F1FF),
+    green = Color(0xFF48B236),
+    badgeGreen = Color(0xFFD9EED3),
+    gray400 = Color(0xFF575B6C),
+    gray300 = Color(0xFF848794),
+    gray200 = Color(0xFFB3B4B6),
+    gray100 = Color(0xFFE8E8E8)
+)
 
 

--- a/presentation/src/main/java/com/meokq/presentation/theme/Theme.kt
+++ b/presentation/src/main/java/com/meokq/presentation/theme/Theme.kt
@@ -1,30 +1,16 @@
 package com.meokq.presentation.theme
 
-import CustomTypo
 import android.app.Activity
-import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.darkColorScheme
-import androidx.compose.material3.dynamicDarkColorScheme
-import androidx.compose.material3.dynamicLightColorScheme
-import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
-
-private val DarkColorScheme = darkColorScheme(
-    background = BackGround,
-    primary = Primary,
-)
-
-private val LightColorScheme = lightColorScheme(
-    background = BackGround,
-    primary = Primary,
-)
+import defaultMeokQTypography
 
 @Composable
 fun MeokQTheme(
@@ -33,27 +19,36 @@ fun MeokQTheme(
     dynamicColor: Boolean = true,
     content: @Composable () -> Unit
 ) {
-    val colorScheme = when {
-        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
-            val context = LocalContext.current
-            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
-        }
-
-        darkTheme -> DarkColorScheme
-        else -> LightColorScheme
-    }
     val view = LocalView.current
     if (!view.isInEditMode) {
-        SideEffect {
-            val window = (view.context as Activity).window
-            window.statusBarColor = colorScheme.primary.toArgb()
-            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = darkTheme
+        CompositionLocalProvider(
+            LocalMeokQColorScheme provides defaultColors,
+        ) {
+            val statusBarColor = LocalMeokQColorScheme.current.primary.toArgb()
+            SideEffect {
+                val window = (view.context as Activity).window
+                window.statusBarColor = statusBarColor
+                WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars =
+                    darkTheme
+            }
         }
     }
 
-    MaterialTheme(
-        colorScheme = colorScheme,
-        typography = CustomTypo,
-        content = content
-    )
+    CompositionLocalProvider(
+        LocalMeokQColorScheme provides defaultColors,
+        LocalMeokQTypography provides defaultMeokQTypography
+    ) {
+        MaterialTheme(
+            content = content
+        )
+    }
+}
+
+object MeokQTheme {
+    val colorScheme: MeokQColorScheme
+        @Composable
+        get() = LocalMeokQColorScheme.current
+    val typography: MeokQTypography
+        @Composable
+        get() = LocalMeokQTypography.current
 }

--- a/presentation/src/main/java/com/meokq/presentation/theme/ThemeGuide.kt
+++ b/presentation/src/main/java/com/meokq/presentation/theme/ThemeGuide.kt
@@ -1,0 +1,94 @@
+package com.meokq.presentation.theme
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.text.TextStyle
+
+import androidx.compose.ui.graphics.Color
+
+@Immutable
+data class MeokQColorScheme(
+    val primary: Color,
+    val notificationYellow: Color,
+    val tabYellow: Color,
+    val badgeYellow: Color,
+    val textYellow: Color,
+    val background: Color,
+    val kakaoLoginButton: Color,
+    val textBlack: Color,
+    val shadowColor: Color,
+    val red: Color,
+    val badgeRed: Color,
+    val blue: Color,
+    val badgeBlue: Color,
+    val green: Color,
+    val badgeGreen: Color,
+    val gray100: Color,
+    val gray200: Color,
+    val gray300: Color,
+    val gray400: Color,
+) {
+}
+
+@Immutable
+data class MeokQTypography(
+    val Title01: TextStyle,
+    val Title02: TextStyle,
+    val Heading01: TextStyle,
+    val Heading02: TextStyle,
+    val Heading03: TextStyle,
+    val Subtitle01: TextStyle,
+    val Subtitle02: TextStyle,
+    val Caption01: TextStyle,
+    val Caption02: TextStyle,
+    val Body: TextStyle,
+    val Button: TextStyle,
+    val TabBold: TextStyle,
+    val TabRegular: TextStyle,
+    val Badge01: TextStyle,
+    val Badge02: TextStyle
+)
+
+val LocalMeokQColorScheme = staticCompositionLocalOf {
+    MeokQColorScheme(
+        primary = Color.Unspecified,
+        notificationYellow = Color.Unspecified,
+        tabYellow = Color.Unspecified,
+        badgeYellow = Color.Unspecified,
+        textYellow = Color.Unspecified,
+        background = Color.Unspecified,
+        kakaoLoginButton = Color.Unspecified,
+        textBlack = Color.Unspecified,
+        shadowColor = Color.Unspecified,
+        red = Color.Unspecified,
+        badgeRed = Color.Unspecified,
+        blue = Color.Unspecified,
+        badgeBlue = Color.Unspecified,
+        green = Color.Unspecified,
+        badgeGreen = Color.Unspecified,
+        gray100 = Color.Unspecified,
+        gray200 = Color.Unspecified,
+        gray300 = Color.Unspecified,
+        gray400 = Color.Unspecified,
+    )
+}
+
+val LocalMeokQTypography = staticCompositionLocalOf {
+    MeokQTypography(
+        Title01 = TextStyle.Default,
+        Title02 = TextStyle.Default,
+        Heading01 = TextStyle.Default,
+        Heading02 = TextStyle.Default,
+        Heading03 = TextStyle.Default,
+        Subtitle01 = TextStyle.Default,
+        Subtitle02 = TextStyle.Default,
+        Caption01 = TextStyle.Default,
+        Caption02 = TextStyle.Default,
+        Body = TextStyle.Default,
+        Button = TextStyle.Default,
+        TabBold = TextStyle.Default,
+        TabRegular = TextStyle.Default,
+        Badge01 = TextStyle.Default,
+        Badge02 = TextStyle.Default
+    )
+}

--- a/presentation/src/main/java/com/meokq/presentation/theme/Type.kt
+++ b/presentation/src/main/java/com/meokq/presentation/theme/Type.kt
@@ -1,11 +1,13 @@
 import androidx.compose.material3.Typography
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.meokq.presentation.R
-import com.meokq.presentation.theme.TextBlack
+import com.meokq.presentation.theme.MeokQTypography
 
 
 // Set of Material typography styles to start with
@@ -15,84 +17,126 @@ val Pretendard = FontFamily(
     Font(R.font.pretendardmedium, FontWeight.Medium),
     Font(R.font.pretendardregular, FontWeight.Normal),
 )
-val CustomTypo = Typography(
-    //title
-    titleLarge = TextStyle(
-        fontFamily = Pretendard,
-        fontWeight = FontWeight.Bold,
-        color = TextBlack,
-        fontSize = 23.sp,
-        lineHeight = 24.sp
-    ), titleMedium = TextStyle(
-        fontFamily = Pretendard,
-        fontWeight = FontWeight.Medium,
-        color = TextBlack,
-        fontSize = 17.sp,
-        lineHeight = 22.sp
-    ),
-    //heading
-    headlineLarge = TextStyle(
-        fontFamily = Pretendard,
-        fontWeight = FontWeight.Medium,
-        color = TextBlack,
-        fontSize = 19.sp,
-        lineHeight = 23.sp
-    ), headlineMedium = TextStyle(
-        fontFamily = Pretendard,
-        fontWeight = FontWeight.Bold,
-        color = TextBlack,
-        fontSize = 17.sp,
-        lineHeight = 20.sp
-    ), headlineSmall = TextStyle(
-        fontFamily = Pretendard,
-        fontWeight = FontWeight.Bold,
-        color = TextBlack,
-        fontSize = 15.sp,
-        lineHeight = 18.sp
-    ),
 
-    //body
-    bodySmall = TextStyle(
+val defaultMeokQTypography = MeokQTypography(
+    Title01 = TextStyle(
+        color = Color.Black,
         fontFamily = Pretendard,
-        fontWeight = FontWeight.Normal,
-        color = TextBlack,
-        fontSize = 15.sp,
-        lineHeight = 22.sp
+        fontWeight = FontWeight.Bold,
+        fontSize = 23.sp,
+        lineHeight = 24.sp,
+        letterSpacing = 0.sp
     ),
-    //caption
-    labelMedium = TextStyle(
+    Title02 = TextStyle(
+        color = Color.Black,
+        fontFamily = Pretendard,
+        fontWeight = FontWeight.Bold,
+        fontSize = 17.sp,
+        lineHeight = 22.sp,
+        letterSpacing = 0.sp
+    ),
+    Heading01 = TextStyle(
+        color = Color.Black,
+        fontFamily = Pretendard,
+        fontWeight = FontWeight.Bold,
+        fontSize = 17.sp,
+        lineHeight = 20.sp,
+        letterSpacing = (-0.4).sp
+    ),
+    Heading02 = TextStyle(
+        color = Color.Black,
+        fontFamily = Pretendard,
+        fontWeight = FontWeight.Bold,
+        fontSize = 15.sp,
+        lineHeight = 18.sp,
+        letterSpacing = (-0.4).sp
+    ),
+    Heading03 = TextStyle(
+        color = Color.Black,
+        fontFamily = Pretendard,
+        fontWeight = FontWeight.Bold,
+        fontSize = 19.sp,
+        lineHeight = 23.sp,
+        letterSpacing = (-0.4).sp
+    ),
+    Subtitle01 = TextStyle(
+        color = Color.Black,
         fontFamily = Pretendard,
         fontWeight = FontWeight.Normal,
-        color = TextBlack,
+        fontSize = 16.sp,
+        lineHeight = 24.sp,
+        letterSpacing = (-0.4).sp
+    ),
+    Subtitle02 = TextStyle(
+        color = Color.Black,
+        fontFamily = Pretendard,
+        fontWeight = FontWeight.Normal,
+        fontSize = 16.sp,
+        lineHeight = 24.sp,
+        letterSpacing = (-0.4).sp
+    ),
+    Caption01 = TextStyle(
+        color = Color.Black,
+        fontFamily = Pretendard,
+        fontWeight = FontWeight.Normal,
         fontSize = 13.sp,
-        lineHeight = 20.sp
-    ), labelSmall = TextStyle(
+        lineHeight = 20.sp,
+        letterSpacing = (-0.3).sp
+    ),
+    Caption02 = TextStyle(
+        color = Color.Black,
         fontFamily = Pretendard,
         fontWeight = FontWeight.Normal,
-        color = TextBlack,
         fontSize = 12.sp,
-        lineHeight = 18.sp
+        lineHeight = 16.sp,
+        letterSpacing = (-0.3).sp
+    ),
+    Body = TextStyle(
+        color = Color.Black,
+        fontFamily = Pretendard,
+        fontWeight = FontWeight.Normal,
+        fontSize = 15.sp,
+        lineHeight = 22.sp,
+        letterSpacing = (-0.3).sp
+    ),
+    Button = TextStyle(
+        color = Color.Black,
+        fontFamily = Pretendard,
+        fontWeight = FontWeight.SemiBold,
+        fontSize = 16.sp,
+        lineHeight = 18.sp,
+        letterSpacing = 0.sp
+    ),
+    TabBold = TextStyle(
+        color = Color.Black,
+        fontFamily = Pretendard,
+        fontWeight = FontWeight.SemiBold,
+        fontSize = 14.sp,
+        lineHeight = 24.sp,
+        letterSpacing = 0.sp
+    ),
+    TabRegular = TextStyle(
+        color = Color.Black,
+        fontFamily = Pretendard,
+        fontWeight = FontWeight.Normal,
+        fontSize = 14.sp,
+        lineHeight = 24.sp,
+        letterSpacing = 0.sp
+    ),
+    Badge01 = TextStyle(
+        color = Color.Black,
+        fontFamily = Pretendard,
+        fontWeight = FontWeight.SemiBold,
+        fontSize = 10.sp,
+        lineHeight = 12.sp,
+        letterSpacing = 0.sp
+    ),
+    Badge02 = TextStyle(
+        color = Color.Black,
+        fontFamily = Pretendard,
+        fontWeight = FontWeight.SemiBold,
+        fontSize = 10.sp,
+        lineHeight = 12.sp,
+        letterSpacing = (-0.3).sp
     )
 )
-val Subtitle01 = CustomTypo.headlineMedium.copy(
-    fontSize = 16.sp, lineHeight = 24.sp, fontWeight = FontWeight.SemiBold
-)
-val Subtitle02 = Subtitle01.copy(fontWeight = FontWeight.Normal)
-val Button = CustomTypo.bodyLarge.copy(
-    fontSize = 16.sp,
-    lineHeight = 18.sp,
-)
-val TabBold = CustomTypo.headlineLarge.copy(
-    fontSize = 14.sp,
-    lineHeight = 24.sp,
-)
-val TabRegular = TabBold.copy(
-    fontWeight = FontWeight.Normal
-)
-val Badge01 = CustomTypo.bodyLarge.copy(
-    fontSize = 10.sp, lineHeight = 12.sp, color = TextBlack
-)
-val Badge02 = TabRegular.copy(
-    fontSize = 10.sp, lineHeight = 12.sp, color = TextBlack
-)
-

--- a/presentation/src/main/java/com/meokq/presentation/ui/coupon/CouponScreen.kt
+++ b/presentation/src/main/java/com/meokq/presentation/ui/coupon/CouponScreen.kt
@@ -1,8 +1,5 @@
 package com.meokq.presentation.ui.coupon
 
-import CustomTypo
-import Subtitle02
-import TabBold
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -30,10 +27,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.meokq.presentation.R
-import com.meokq.presentation.theme.BackGround
-import com.meokq.presentation.theme.Gray200
-import com.meokq.presentation.theme.NotificationYellow
-import com.meokq.presentation.theme.White
+import com.meokq.presentation.theme.MeokQTheme
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -44,7 +38,7 @@ fun CouponScreen(couponViewModel: CouponViewModel = hiltViewModel()) {
     ) {
         Text(
             modifier = Modifier.padding(vertical = 10.dp),
-            text = "쿠폰", style = CustomTypo.titleMedium
+            text = "쿠폰", style = MeokQTheme.typography.Title02
         )
         var pagerState = rememberPagerState(pageCount = { 4 })
         val coroutineScope = rememberCoroutineScope()
@@ -54,14 +48,14 @@ fun CouponScreen(couponViewModel: CouponViewModel = hiltViewModel()) {
         )
         TabRow(
             selectedTabIndex = pagerState.currentPage,
-            containerColor = White,
-            contentColor = White,
+            containerColor = Color.White,
+            contentColor = Color.White,
             indicator = { tabPositions ->
                 TabRowDefaults.Indicator(
                     modifier = Modifier
                         .tabIndicatorOffset(tabPositions[pagerState.currentPage])
                         .width(59.dp),
-                    color = NotificationYellow,
+                    color = MeokQTheme.colorScheme.notificationYellow,
                 )
             },
         ) {
@@ -76,8 +70,8 @@ fun CouponScreen(couponViewModel: CouponViewModel = hiltViewModel()) {
                     Row {
                         Text(
                             text = title,
-                            style = TabBold.copy(
-                                color = if (isSelected) Color.Black else Gray200
+                            style = MeokQTheme.typography.TabBold.copy(
+                                color = if (isSelected) MeokQTheme.colorScheme.textBlack else MeokQTheme.colorScheme.gray200
 
                             ),
                             maxLines = 1,
@@ -85,8 +79,8 @@ fun CouponScreen(couponViewModel: CouponViewModel = hiltViewModel()) {
                         //TODO 숫자 data 추가
                         Text(
                             text = " 1",
-                            style = TabBold.copy(
-                                color = if (isSelected) NotificationYellow else Gray200
+                            style = MeokQTheme.typography.TabBold.copy(
+                                color = if (isSelected) MeokQTheme.colorScheme.notificationYellow else MeokQTheme.colorScheme.gray200
                             ),
                             maxLines = 1,
                         )
@@ -101,12 +95,12 @@ fun CouponScreen(couponViewModel: CouponViewModel = hiltViewModel()) {
                     modifier = Modifier
                         .fillMaxWidth()
                         .fillMaxHeight()
-                        .background(color = BackGround),
+                        .background(color = MeokQTheme.colorScheme.background),
                     contentAlignment = Alignment.Center
                 ) {
                     Text(
                         text = stringResource(R.string.store_mission_empty),
-                        style = Subtitle02.copy(
+                        style = MeokQTheme.typography.Subtitle02.copy(
                             color = Color(0xFFA4A4A4)
                         )
                     )
@@ -114,7 +108,7 @@ fun CouponScreen(couponViewModel: CouponViewModel = hiltViewModel()) {
             LazyColumn(
                 modifier = Modifier
                     .fillMaxHeight()
-                    .background(color = BackGround)
+                    .background(color = MeokQTheme.colorScheme.background)
                     .padding(horizontal = 20.dp, vertical = 15.dp),
                 verticalArrangement = Arrangement.spacedBy(12.dp),
             ) {

--- a/presentation/src/main/java/com/meokq/presentation/ui/global/Badge.kt
+++ b/presentation/src/main/java/com/meokq/presentation/ui/global/Badge.kt
@@ -1,6 +1,5 @@
 package com.meokq.presentation.ui.global
 
-import Badge01
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
@@ -11,7 +10,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import com.meokq.presentation.theme.BadgeYellow
+import com.meokq.presentation.theme.MeokQTheme
 
 @Composable
 fun TextBadge(
@@ -30,7 +29,7 @@ fun TextBadge(
                 horizontal = 8.dp,
                 vertical = 3.dp
             ),
-        text = text, style = Badge01.copy(
+        text = text, style = MeokQTheme.typography.Badge01.copy(
             color = textColor
         )
     )

--- a/presentation/src/main/java/com/meokq/presentation/ui/nav/MeokQNavBar.kt
+++ b/presentation/src/main/java/com/meokq/presentation/ui/nav/MeokQNavBar.kt
@@ -1,6 +1,5 @@
 package com.meokq.presentation.ui.nav
 
-import Badge01
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.animateFloatAsState
@@ -27,8 +26,7 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
-import com.meokq.presentation.theme.Gray200
-import com.meokq.presentation.theme.Gray400
+import com.meokq.presentation.theme.MeokQTheme
 
 data class BottomNavigationItem(
     val text: String,
@@ -78,7 +76,7 @@ fun BottomNavigationItem(
         Spacer(modifier = Modifier.height(8.dp))
         Text(
             text = item.text,
-            style = Badge01.copy(color = if (isSelected) Gray400 else Gray200)
+            style = MeokQTheme.typography.Badge01.copy(color = if (isSelected) MeokQTheme.colorScheme.gray400 else MeokQTheme.colorScheme.gray200)
         )
     }
 }

--- a/presentation/src/main/java/com/meokq/presentation/ui/quest/QuestScreen.kt
+++ b/presentation/src/main/java/com/meokq/presentation/ui/quest/QuestScreen.kt
@@ -1,6 +1,5 @@
 package com.meokq.presentation.ui.quest
 
-import CustomTypo
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -38,13 +37,7 @@ import androidx.navigation.compose.rememberNavController
 import coil.compose.AsyncImage
 import com.meokq.presentation.R
 import com.meokq.presentation.model.QuestUIModel
-import com.meokq.presentation.theme.BackGround
-import com.meokq.presentation.theme.BadgeYellow
-import com.meokq.presentation.theme.Gray200
-import com.meokq.presentation.theme.Gray400
-import com.meokq.presentation.theme.Primary
-import com.meokq.presentation.theme.TextYellow
-import com.meokq.presentation.theme.White
+import com.meokq.presentation.theme.MeokQTheme
 import com.meokq.presentation.ui.global.TextBadge
 import com.meokq.presentation.ui.nav.MeokQDestination
 
@@ -57,13 +50,13 @@ fun QuestScreen(
         modifier = Modifier
             .fillMaxWidth()
             .fillMaxHeight()
-            .background(color = BackGround)
+            .background(color = MeokQTheme.colorScheme.background)
     ) {
         ConstraintLayout(
             modifier = Modifier
                 .fillMaxWidth()
                 .background(
-                    color = Primary,
+                    color = MeokQTheme.colorScheme.primary,
                 )
                 .padding(vertical = 12.dp, horizontal = 30.dp)
         ) {
@@ -77,7 +70,7 @@ fun QuestScreen(
                     start.linkTo(parent.start)
                     end.linkTo(parent.end)
 
-                }, text = "서울 강남구", style = CustomTypo.titleMedium
+                }, text = "서울 강남구", style = MeokQTheme.typography.Title02
             )
             Image(
                 modifier = Modifier
@@ -139,7 +132,7 @@ fun QuestCard(
             }
             .fillMaxWidth()
             .background(
-                color = White, shape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp)
+                color = Color.White, shape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp)
             )
             .padding(16.dp),
 
@@ -165,14 +158,14 @@ fun QuestCard(
         ) {
             Row {
                 Text(
-                    text = uiModel.name, style = CustomTypo.headlineMedium.copy(
+                    text = uiModel.name, style = MeokQTheme.typography.Heading01.copy(
                         lineHeight = 21.sp
                     )
                 )
                 Spacer(modifier = Modifier.width(8.dp))
                 TextBadge(
-                    backgroundColor = BadgeYellow,
-                    textColor = TextYellow,
+                    backgroundColor = MeokQTheme.colorScheme.badgeYellow,
+                    textColor = MeokQTheme.colorScheme.textYellow,
                     text = "퀘스트 ${uiModel.missionCount}개"
                 )
             }
@@ -189,7 +182,7 @@ fun QuestCard(
             modifier = Modifier.height(18.dp),
             painter = painterResource(id = R.drawable.ic_arrow_forward),
             contentDescription = null,
-            colorFilter = ColorFilter.tint(color = Gray200),
+            colorFilter = ColorFilter.tint(color = MeokQTheme.colorScheme.gray200),
         )
     }
 }
@@ -211,7 +204,7 @@ fun StoreInfo(
         Spacer(modifier = Modifier.width(5.dp))
         Text(
             text = text,
-            style = CustomTypo.labelSmall.copy(color = Gray400),
+            style = MeokQTheme.typography.Caption02.copy(color = MeokQTheme.colorScheme.gray400),
             overflow = TextOverflow.Ellipsis,
             maxLines = 2,
         )

--- a/presentation/src/main/java/com/meokq/presentation/ui/signin/LoginScreen.kt
+++ b/presentation/src/main/java/com/meokq/presentation/ui/signin/LoginScreen.kt
@@ -1,7 +1,5 @@
 package com.meokq.presentation.ui.signin
 
-import CustomTypo
-import TabRegular
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -31,10 +29,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.meokq.presentation.R
-import com.meokq.presentation.theme.Gray300
-import com.meokq.presentation.theme.KakaoLoginButton
-import com.meokq.presentation.theme.Primary
-import com.meokq.presentation.theme.White
+import com.meokq.presentation.theme.MeokQTheme
 
 @Preview
 @Composable
@@ -45,7 +40,7 @@ fun LoginScreen(
         modifier = Modifier
             .fillMaxHeight()
             .fillMaxWidth()
-            .background(color = White),
+            .background(color = Color.White),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center
 
@@ -64,13 +59,13 @@ fun LoginScreen(
         LoginButton(
             text = stringResource(R.string.text_button_sign_in_kakao),
             painter = painterResource(id = R.drawable.ic_login_kakao_18),
-            backgroundColor = KakaoLoginButton
+            backgroundColor = MeokQTheme.colorScheme.kakaoLoginButton
         )
         Spacer(modifier = Modifier.height(27.dp))
         LoginButton(
             text = stringResource(R.string.text_button_sign_in_google),
             painter = painterResource(id = R.drawable.ic_login_google_18),
-            backgroundColor = White,
+            backgroundColor = Color.White,
             isBorder = true
         )
         Spacer(modifier = Modifier.height(25.dp))
@@ -80,7 +75,7 @@ fun LoginScreen(
                 onClick = onNavigate
             ),
             text = stringResource(R.string.login_skip),
-            style = CustomTypo.labelSmall.copy(color = Gray300),
+            style = MeokQTheme.typography.Caption02.copy(color = MeokQTheme.colorScheme.gray300),
             textDecoration = TextDecoration.Underline
         )
     }
@@ -112,7 +107,7 @@ fun LoginButton(
         )
         Text(
             text = text,
-            style = TabRegular
+            style = MeokQTheme.typography.TabRegular
         )
         Text(
             text = "",

--- a/presentation/src/main/java/com/meokq/presentation/ui/store/StoreScreen.kt
+++ b/presentation/src/main/java/com/meokq/presentation/ui/store/StoreScreen.kt
@@ -1,8 +1,5 @@
 package com.meokq.presentation.ui.store
 
-import CustomTypo
-import Subtitle02
-import TabBold
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -34,11 +31,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
-import coil.compose.AsyncImage
-import com.meokq.presentation.R
-import com.meokq.presentation.theme.BadgeYellow
-import com.meokq.presentation.theme.Gray200
-import com.meokq.presentation.theme.TextYellow
 import com.meokq.presentation.ui.global.TextBadge
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRowDefaults
@@ -47,11 +39,11 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.graphics.Color.Companion.Black
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
+import coil.compose.AsyncImage
+import com.meokq.presentation.R
 import com.meokq.presentation.model.QuestStatus
 import com.meokq.presentation.model.questStatusMap
-import com.meokq.presentation.theme.BackGround
-import com.meokq.presentation.theme.NotificationYellow
-import com.meokq.presentation.theme.White
+import com.meokq.presentation.theme.MeokQTheme
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -98,7 +90,7 @@ fun StoreScreen(
             Spacer(modifier = Modifier.width(17.dp))
             Column {
                 Text(
-                    text = uiModel.name, style = CustomTypo.headlineMedium.copy(
+                    text = uiModel.name, style = MeokQTheme.typography.Heading01.copy(
                         lineHeight = 21.sp
                     )
                 )
@@ -106,8 +98,8 @@ fun StoreScreen(
 
                 Row {
                     Text(
-                        text = uiModel.address, style = CustomTypo.labelMedium.copy(
-                            color = Gray200
+                        text = uiModel.address, style = MeokQTheme.typography.Caption01.copy(
+                            color = MeokQTheme.colorScheme.gray200
                         )
                     )
                     Spacer(modifier = Modifier.width(5.dp))
@@ -131,7 +123,7 @@ fun StoreScreen(
                     )
                     storeInfo.forEach { info ->
                         TextBadge(
-                            backgroundColor = BadgeYellow, textColor = TextYellow, text = info
+                            backgroundColor = MeokQTheme.colorScheme.badgeYellow, textColor = MeokQTheme.colorScheme.textYellow, text = info
                         )
                     }
                 }
@@ -143,14 +135,14 @@ fun StoreScreen(
         //2. Tab
         TabRow(
             selectedTabIndex = pagerState.currentPage,
-            containerColor = White,
-            contentColor = White,
+            containerColor = Color.White,
+            contentColor = Color.White,
             indicator = { tabPositions ->
                 TabRowDefaults.Indicator(
                     modifier = Modifier
                         .tabIndicatorOffset(tabPositions[pagerState.currentPage])
                         .width(59.dp),
-                    color = NotificationYellow,
+                    color = MeokQTheme.colorScheme.notificationYellow,
                 )
             },
         ) {
@@ -165,8 +157,8 @@ fun StoreScreen(
                     Row {
                         Text(
                             text = title,
-                            style = TabBold.copy(
-                                color = if (isSelected) Black else Gray200
+                            style = MeokQTheme.typography.TabBold.copy(
+                                color = if (isSelected) Black else MeokQTheme.colorScheme.gray200
 
                             ),
                             maxLines = 1,
@@ -174,8 +166,8 @@ fun StoreScreen(
                         //TODO 숫자 data 추가
                         Text(
                             text = " 1",
-                            style = TabBold.copy(
-                                color = if (isSelected) NotificationYellow else Gray200
+                            style = MeokQTheme.typography.TabBold.copy(
+                                color = if (isSelected) MeokQTheme.colorScheme.notificationYellow else MeokQTheme.colorScheme.gray200
                             ),
                             maxLines = 1,
                         )
@@ -189,12 +181,12 @@ fun StoreScreen(
                 Box(
                     modifier = Modifier
                         .fillMaxHeight()
-                        .background(color = BackGround),
+                        .background(color = MeokQTheme.colorScheme.background),
                     contentAlignment = Alignment.Center
                 ) {
                     Text(
                         text = stringResource(R.string.store_mission_empty),
-                        style = Subtitle02.copy(
+                        style = MeokQTheme.typography.Subtitle02.copy(
                             color = Color(0xFFA4A4A4)
                         )
                     )
@@ -202,7 +194,7 @@ fun StoreScreen(
             LazyColumn(
                 modifier = Modifier
                     .fillMaxHeight()
-                    .background(color = BackGround)
+                    .background(color = MeokQTheme.colorScheme.background)
                     .padding(horizontal = 20.dp, vertical = 15.dp),
                 verticalArrangement = Arrangement.spacedBy(12.dp),
             ) {

--- a/presentation/src/main/java/com/meokq/presentation/ui/store/StoreWidget.kt
+++ b/presentation/src/main/java/com/meokq/presentation/ui/store/StoreWidget.kt
@@ -1,6 +1,5 @@
 package com.meokq.presentation.ui.store
 
-import CustomTypo
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -22,8 +21,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.meokq.presentation.R
 import com.meokq.presentation.model.QuestStatus
-import com.meokq.presentation.theme.Gray300
-import com.meokq.presentation.theme.White
+import com.meokq.presentation.model.ui
+import com.meokq.presentation.theme.MeokQTheme
 import com.meokq.presentation.ui.global.TextBadge
 
 @Preview
@@ -50,7 +49,7 @@ fun MissionInfo(
                 ambientColor = Color(0x0D7D7D7D)
             )
             .fillMaxWidth()
-            .background(color = White, shape = RoundedCornerShape(size = 12.dp))
+            .background(color = Color.White, shape = RoundedCornerShape(size = 12.dp))
             .clickable {
                 //TODO add copy clipboar logic
             }
@@ -63,16 +62,16 @@ fun MissionInfo(
             horizontalAlignment = Alignment.Start
         ) {
             TextBadge(
-                backgroundColor = status.backgroundColor,
-                textColor = status.textColor,
-                text = status.text
+                backgroundColor = status.ui().backgroundColor,
+                textColor = status.ui().textColor,
+                text = status.ui().text
             )
             Text(
-                text = reward, style = CustomTypo.headlineLarge
+                text = reward, style = MeokQTheme.typography.Heading03
             )
             Text(
-                text = missionDescription, style = CustomTypo.labelMedium.copy(
-                    color = Gray300
+                text = missionDescription, style = MeokQTheme.typography.Caption01.copy(
+                    color = MeokQTheme.colorScheme.gray300
                 )
             )
         }


### PR DESCRIPTION
## ‼️ 관련 이슈
close #14 

## ✨ PR Point
- 1 기존 Material Theme 의 ColorScheme 을 자체 ColorScheme 으로 교체 (MeokQColorScheme)
- 2 기존 Material Theme 의 Typography를 자체 Typography 로 교체 (MeokQTypography)

## To Reviewers
> 참고사항및 특이점이 있으면 적어주세요
- 1 컬러 및 서체 이용시 다음과 같이 합니다.
```
MeokQTheme.colorScheme.badgeYellow

MeokQTheme.typography.TabBold
```
- 2 Preview 이용시 MeokQTheme 로 한번 감싸주어야 테마가 적용 된 상태의 미리보기가 가능합니다.
```
@Preview
@Composable
fun StoreScreenPreview(){
    MeokQTheme {
        StoreScreen()
    }
}
```
- 3 서체 및 컬러 추가시 다음과 같이 합니다.

1. ThemeGuide.kt 파일에서 추가하려는 컬러 혹은 서체를 data class 의 변수로 지정
2. ThemeGuide.kt 에 있는 composition local 에 있는 디폴트 data class 에 Color.Unspecified 또는 TextStyle.Default 등 기본 값 지정
3. Color.kt 또는 Type.kt 에서 실제 테마 지정 값 기입
